### PR TITLE
Add Player Camera Controller

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -44,6 +44,26 @@ ui_close_radial_menu={
 , Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
+camera_forward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+camera_backward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+camera_left={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+camera_right={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 

--- a/project/src/Player/CameraController.gd
+++ b/project/src/Player/CameraController.gd
@@ -1,0 +1,29 @@
+extends Spatial
+
+# Export parameters exposing them to godots editor's inspector panel
+export (float, 0, 100) var movement_speed
+
+# Set variables time of load
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass
+
+# Overides the process() function (Adds functionality to the main loop.)
+func _process(delta):
+	_move(delta)
+
+# Movement functions
+func _move(delta: float) -> void:
+	var velocity = Vector3()
+	if Input.is_action_pressed("camera_forward"):
+		velocity -= transform.basis.z
+	if Input.is_action_pressed("camera_backward"):
+		velocity += transform.basis.z
+	if Input.is_action_pressed("camera_left"):
+		velocity -= transform.basis.x
+	if Input.is_action_pressed("camera_right"):
+		velocity += transform.basis.x
+	velocity = velocity.normalized()
+	translation += velocity * delta * movement_speed

--- a/project/src/Player/PlayerCamera.tscn
+++ b/project/src/Player/PlayerCamera.tscn
@@ -1,6 +1,12 @@
-[gd_scene format=2]
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://src/Player/CameraController.gd" type="Script" id=1]
 
 [node name="PlayerCamera" type="Spatial"]
 
-[node name="Camera" type="Camera" parent="."]
+[node name="CameraController" type="Spatial" parent="."]
+script = ExtResource( 1 )
+movement_speed = 20.608
+
+[node name="Camera" type="Camera" parent="CameraController"]
 transform = Transform( 1, 0, 0, 0, 0.5, 0.866025, 0, -0.866025, 0.5, 0, 0, 0 )


### PR DESCRIPTION
Player can move camera using the WASD keys.
A Developer can add new control schemes for the camera movement.

https://user-images.githubusercontent.com/69282314/201799266-6d77e4b2-abfa-429d-93f1-6117a3871924.mp4

Node structure for PlayerCamera:
![image](https://user-images.githubusercontent.com/69282314/201799485-38f5cb50-28a9-4c7b-9271-11665d22fb3c.png)
