### PR TITLE
Center the radial menu in the game window

### DIFF
--- a/project/src/UI/DynamicUI.tscn
+++ b/project/src/UI/DynamicUI.tscn
@@ -34,8 +34,14 @@ script = ExtResource( 2 )
 
 [node name="RadialMenu" type="Control" parent="."]
 visible = false
-margin_right = 40.0
-margin_bottom = 40.0
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -20.0
+margin_top = -20.0
+margin_right = 20.0
+margin_bottom = 20.0
 script = ExtResource( 4 )
 
 [node name="RadialMenuBackground" type="Container" parent="RadialMenu"]
@@ -43,10 +49,10 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = 302.5
-margin_top = 95.0
-margin_right = 674.5
-margin_bottom = 467.0
+margin_left = -186.0
+margin_top = -186.0
+margin_right = 186.0
+margin_bottom = 186.0
 script = SubResource( 1 )
 
 [node name="AspectRatioContainer" type="AspectRatioContainer" parent="RadialMenu/RadialMenuBackground"]
@@ -60,16 +66,19 @@ self_modulate = Color( 1, 1, 1, 0.478431 )
 texture = ExtResource( 1 )
 
 [node name="Line2D" type="Line2D" parent="RadialMenu"]
-position = Vector2( 483, 145 )
-points = PoolVector2Array( 0, 0, 0, 300 )
+position = Vector2( -2.5, -130 )
+points = PoolVector2Array( 0, 0, 0, 42.339, 0, 300 )
 width = 2.0
 default_color = Color( 0, 0, 0, 1 )
 
 [node name="RadialMenuItem" type="CenterContainer" parent="RadialMenu"]
-margin_left = 367.0
-margin_top = 287.0
-margin_right = 423.0
-margin_bottom = 301.0
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -140.5
+margin_top = -14.0
+margin_right = -84.5
 script = ExtResource( 3 )
 
 [node name="RadialMenuItemLabel" type="Label" parent="RadialMenu/RadialMenuItem"]
@@ -81,10 +90,14 @@ margin_bottom = 14.0
 text = "Ranged"
 
 [node name="RadialMenuItem2" type="CenterContainer" parent="RadialMenu"]
-margin_left = 552.0
-margin_top = 287.0
-margin_right = 608.0
-margin_bottom = 301.0
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = 35.5
+margin_top = -12.0
+margin_right = 91.5
+margin_bottom = 2.0
 script = ExtResource( 3 )
 
 [node name="RadialMenuItemLabel" type="Label" parent="RadialMenu/RadialMenuItem2"]


### PR DESCRIPTION
Centers the radial menu on screen regardless of screen size.

## Example showing resizing the screen and radial menu remains centered

https://user-images.githubusercontent.com/23508546/201801904-024af870-73a4-4383-80ee-ee8103dddbfc.mp4

## I used the center layout option for the RadialMenu

![Snag_72012f78](https://user-images.githubusercontent.com/23508546/201802066-f93dc3d0-93c5-45a9-9df7-1a398e110991.png)



Fixes #7