### PR TITLE
Add interaction that despawn the soul asset.

### DIFF
--- a/project/src/Player/CameraController.gd
+++ b/project/src/Player/CameraController.gd
@@ -41,6 +41,9 @@ func _move(delta: float) -> void:
 	velocity = velocity.normalized()
 	translation += velocity * delta * movement_speed
 	
+	if Input.is_action_just_pressed("ui_accept") and get_world_grid_cell_item() == 0:
+		set_world_grid_cell_item(-1)
+	
 # Cursor functions
 func _cursor_follow_camera(delta: float) -> void:
 	if !ray.is_colliding():
@@ -58,3 +61,14 @@ func _cursor_follow_camera(delta: float) -> void:
 		cursor.global_transform.origin = selection_grid_map_position
 		#set the cursor to visible
 		cursor.visible = true
+		print(get_world_grid_cell_item())
+# Cursor Helper Functions
+func get_world_grid_cell_item() -> int:
+	return _grid_map.world_grid.get_cell_item(grid_map_intersection.x,
+											  grid_map_intersection.y,
+											  grid_map_intersection.z)
+func set_world_grid_cell_item(mesh_lib_item: int) -> void:
+	_grid_map.world_grid.set_cell_item(grid_map_intersection.x,
+									   grid_map_intersection.y,
+									   grid_map_intersection.z,
+									   mesh_lib_item)

--- a/project/src/Player/PlayerCamera.gd
+++ b/project/src/Player/PlayerCamera.gd
@@ -1,0 +1,3 @@
+extends GridMap
+
+onready var world_grid = get_parent().get_node("Ground")

--- a/project/src/Player/PlayerCamera.tscn
+++ b/project/src/Player/PlayerCamera.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://src/Player/CameraController.gd" type="Script" id=1]
+[ext_resource path="res://src/Player/PlayerCamera.gd" type="Script" id=2]
 
 [sub_resource type="CubeMesh" id=1]
 size = Vector3( 1, 1, 1 )
@@ -11,6 +12,7 @@ albedo_color = Color( 0, 0.662745, 0.164706, 1 )
 [node name="PlayerCamera" type="GridMap"]
 cell_size = Vector3( 1, 1, 1 )
 cell_center_y = false
+script = ExtResource( 2 )
 __meta__ = {
 "_editor_clip_": 0
 }

--- a/project/src/test/loteque_test_world.tscn
+++ b/project/src/test/loteque_test_world.tscn
@@ -1,24 +1,17 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://src/Player/PlayerCamera.tscn" type="PackedScene" id=1]
-
-[sub_resource type="BoxShape" id=1]
-
-[sub_resource type="CubeMesh" id=2]
-
-[sub_resource type="SpatialMaterial" id=3]
+[ext_resource path="res://src/Ground.tscn" type="PackedScene" id=2]
 
 [node name="Spatial" type="Spatial"]
 
 [node name="PlayerCamera" parent="." instance=ExtResource( 1 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0 )
 
-[node name="Ground" type="Area" parent="."]
-transform = Transform( 8, 0, 0, 0, 0.02, 0, 0, 0, 8, 0, 0, 0 )
-
-[node name="CollisionShape" type="CollisionShape" parent="Ground"]
-shape = SubResource( 1 )
-
-[node name="MeshInstance" type="MeshInstance" parent="Ground"]
-mesh = SubResource( 2 )
-material/0 = SubResource( 3 )
+[node name="Ground" parent="." instance=ExtResource( 2 )]
+data = {
+"cells": PoolIntArray( 65535, 65532, 0 )
+}
+__meta__ = {
+"_editor_clip_": 0,
+"_editor_floor_": Vector3( 0, 0, 0 )
+}


### PR DESCRIPTION
When the player move the cursor under the soul asset and presses the "ui_accept" key the soul asset is removed from the scene. 

(note: this video shows the game state with  patch #15 applied.)

https://user-images.githubusercontent.com/69282314/202803463-3c38618c-2a0f-41f9-84d9-f49360913bf2.mp4


