### PR TITLE
Add a voiceover node

### DIFF
--- a/project/src/Audio/VoiceOver.tscn
+++ b/project/src/Audio/VoiceOver.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=2]
+
+[node name="VoiceOver" type="Node"]

--- a/project/src/Main.tscn
+++ b/project/src/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://src/Ground.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/Audio/Ambience.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://src/Player/PlayerController.tscn" type="PackedScene" id=6]
 [ext_resource path="res://src/Main.gd" type="Script" id=7]
 [ext_resource path="res://src/Mall/MallEnvirnmentModel.tscn" type="PackedScene" id=8]
+[ext_resource path="res://src/Audio/VoiceOver.tscn" type="PackedScene" id=9]
 
 [node name="Main" type="Spatial"]
 script = ExtResource( 7 )
@@ -28,3 +29,5 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.18389, 0 )
 [node name="StaticUI" parent="Mall" instance=ExtResource( 3 )]
 
 [node name="DynamicUI" parent="Mall" instance=ExtResource( 5 )]
+
+[node name="VoiceOver" parent="Mall" instance=ExtResource( 9 )]


### PR DESCRIPTION
This PR adds an empty voice over scene node to the main scene as a child of the Mall node.
![image](https://user-images.githubusercontent.com/69282314/203433629-49f23ef7-3a12-4710-8411-872ccd9010d7.png)
