### PR TITLE
Adds a StartPauseMenu scene to the DynamicUI Scene

### DIFF
--- a/project/src/UI/DynamicUI.tscn
+++ b/project/src/UI/DynamicUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://asset/RadialMenu/radial-menu-background.png" type="Texture" id=1]
 [ext_resource path="res://src/UI/DynamicUI.gd" type="Script" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://src/UI/RadialMenu.gd" type="Script" id=4]
 [ext_resource path="res://asset/DynamicUI/RobotFace.png" type="Texture" id=5]
 [ext_resource path="res://src/UI/DialogUI.gd" type="Script" id=6]
+[ext_resource path="res://src/UI/StartPauseMenu.tscn" type="PackedScene" id=7]
 
 [sub_resource type="GDScript" id=1]
 script/source = "extends Container
@@ -171,3 +172,5 @@ text = "AI Voice"
 [node name="AdvanceButton" type="Polygon2D" parent="DialogUI/DialogBox"]
 position = Vector2( 249.5, 111 )
 polygon = PoolVector2Array( 58, 74, 100, 74, 79, 102 )
+
+[node name="StartPauseMenu" parent="." instance=ExtResource( 7 )]

--- a/project/src/UI/StartPauseMenu.tscn
+++ b/project/src/UI/StartPauseMenu.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=2]
+
+[node name="StartPauseMenu" type="Node"]


### PR DESCRIPTION
This creates a scene container called StartPauseMenu which can be used to contain all of the future start/pause screen UI


## The new scene:
![image](https://user-images.githubusercontent.com/23508546/204118716-906524a6-3bbe-4e24-9924-b2ccced117aa.png)

## The new hierarchy of the DynamicUI scene:
![image](https://user-images.githubusercontent.com/23508546/204118722-f36b19c8-703c-4f4d-b81e-aa8224bb2145.png)


Closes #33