### PR TITLE
Pause Screen adds Ambient sounds

### DIFF
--- a/project/src/Audio/Ambience.gd
+++ b/project/src/Audio/Ambience.gd
@@ -1,0 +1,16 @@
+extends Spatial
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#	pass

--- a/project/src/Audio/Ambience.tscn
+++ b/project/src/Audio/Ambience.tscn
@@ -1,10 +1,55 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://asset/Audio/Ambience/MALL_AMBIENCE.wav" type="AudioStream" id=1]
+[ext_resource path="res://src/Audio/Ambience.gd" type="Script" id=2]
+[ext_resource path="res://src/Mall/MallEnvirnmentModel.tscn" type="PackedScene" id=3]
 
 [node name="Ambience" type="Spatial"]
+pause_mode = 2
+script = ExtResource( 2 )
 
-[node name="AudioStreamPlayer3D" type="AudioStreamPlayer3D" parent="."]
+[node name="MallEnvirnmentModel" parent="." instance=ExtResource( 3 )]
+
+[node name="AC" type="Spatial" parent="."]
+
+[node name="AudioStreamPlayer3D" type="AudioStreamPlayer3D" parent="AC"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 20, 9, 0 )
+stream = ExtResource( 1 )
+unit_db = 2.0
+unit_size = 2.0
+autoplay = true
+max_distance = 60.0
+bus = "Ambience"
+emission_angle_degrees = 90.0
+
+[node name="AC2" type="Spatial" parent="."]
+
+[node name="AudioStreamPlayer3D" type="AudioStreamPlayer3D" parent="AC2"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -20, 9, 0 )
+stream = ExtResource( 1 )
+unit_db = 2.0
+unit_size = 2.0
+autoplay = true
+max_distance = 60.0
+bus = "Ambience"
+emission_angle_degrees = 90.0
+
+[node name="AC3" type="Spatial" parent="."]
+
+[node name="AudioStreamPlayer3D" type="AudioStreamPlayer3D" parent="AC3"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9, 20 )
+stream = ExtResource( 1 )
+unit_db = 2.0
+unit_size = 2.0
+autoplay = true
+max_distance = 60.0
+bus = "Ambience"
+emission_angle_degrees = 90.0
+
+[node name="AC4" type="Spatial" parent="."]
+
+[node name="AudioStreamPlayer3D" type="AudioStreamPlayer3D" parent="AC4"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9, -20 )
 stream = ExtResource( 1 )
 unit_db = 2.0
 unit_size = 2.0

--- a/project/src/Main.tscn
+++ b/project/src/Main.tscn
@@ -25,7 +25,6 @@ script = ExtResource( 7 )
 [node name="Music" parent="Mall" instance=ExtResource( 4 )]
 
 [node name="Ambience" parent="Mall" instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 9.18389, 0 )
 
 [node name="StaticUI" parent="Mall" instance=ExtResource( 3 )]
 


### PR DESCRIPTION
We allowed the audio from the ambience node to be played in the pause menu so the game will always have a continuous ambient track. We have also duplicated the AC node so you can hear the AC sounds from multiple points in the mall. These positions may change in the future.

https://user-images.githubusercontent.com/98199398/207197505-a3f12b66-3697-4a93-bc61-480987eaf761.mp4

